### PR TITLE
Generic http client

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.4
+current_version = 0.2.0
 tag = True
 commit = True
 message = "Bump version {current_version} -> {new_version}"

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 APP := "tx_clients"
-VERSION := "0.1.4" # Managed by bumpversion. Do not modify.
+VERSION := "0.2.0" # Managed by bumpversion. Do not modify.
 
 bumpmicro: ## Bump the micro (patch) version of the package. Auto generates a tag and a commit.
 	bumpversion patch

--- a/environment.yml
+++ b/environment.yml
@@ -9,5 +9,6 @@ dependencies:
     - pylint
     - coverage
     - wrapt
+    - mock
     - pip:
         - bumpversion

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: "tx_clients"
-  version: "0.1.4" # Managed by bumpversion. Do not modify.
+  version: "0.2.0" # Managed by bumpversion. Do not modify.
 
 source:
   git_rev: {{ environ.get('CIRCLE_BRANCH', '') }}
@@ -34,6 +34,7 @@ test:
   requires:
     - pylint
     - coverage
+    - mock
   commands:
     - make test
     - make lint

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-__version__ = "0.1.4" # Managed by bumpversion. Do not modify.
+__version__ = "0.2.0" # Managed by bumpversion. Do not modify.
 
 setup(
     name='tx_clients',

--- a/src/tx_clients/__init__.py
+++ b/src/tx_clients/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "0.1.4" # Managed by bumpversion. Do not modify.
+__version__ = "0.2.0" # Managed by bumpversion. Do not modify.

--- a/src/tx_clients/clients/README.md
+++ b/src/tx_clients/clients/README.md
@@ -1,0 +1,153 @@
+# Clients
+A collection of clients and helpers written using the twisted framework
+
+## Http Client
+This http client provides wrappers around [twisted.web.client.Agent][]. These wrappers provide a "requests" like interface that satisfies a majority of use cases. Consider this library a bicycle with training wheels. For more advanced use cases use the Twisted Agent directly.
+
+### Anatomy of an Agent
+See: [twisted.web.iweb.IAgent][]  
+
+An Agent is passed a reactor and optionally a context factory and connection pool. 
+
+See: [twisted.web.client.WebClientContextFactory][]  
+See: [twisted.web._newclient.HTTP11ClientProtocol][] 
+
+An Agent makes requests with a HTTP verb, and url. You can optionally provide headers and a body producer. 
+
+See: [twisted.web.http_headers.Headers][]  
+See: [twisted.web.iweb.IBodyProducer][] 
+
+### Using an Agent
+You can use the twisted agent directly [Twisted 12.2.0 Client Documentation][].
+Use of [twisted.web.client.getPage][] and [twisted.web.client.downloadPage][] is __strongly__ discouraged. It uses a legacy API and has many shortcomings.
+
+Twisted 12.2.0 provides the following Agents
+
+* [twisted.web.client.Agent][]
+* [twisted.web.client.ProxyAgent][]
+* [twisted.web.client.CookieAgent][]
+* [twisted.web.client.ContentDecoderAgent][]
+* [twisted.web.client.RedirectAgent][]
+
+### Using Agent Helpers
+For convenience the provided helpers are subclasses of [twisted.web.client.Agent][] and may be easier to use. The interface is similar to using the requests library.
+
+NOTE: Helpers have only been created for [twisted.web.client.Agent][] and not other Agent classes. Each agent may have a slightly different __init__ method and process for making requests. Id like to turn the helpers into a Mixin that wraps a [twisted.web.iweb.IAgent][] but we need to upgrade Twisted >= 15.0.0.
+
+#### Whats different?
+HTTP Verbs are mapped to methods on the Agent.
+
+    agent.request('GET', url) == agent.get(url)
+
+A bodyProducer has been set upon each agent helper. This producer will wrap what is passed into data.
+
+__BasicAgent__
+
+    # BasicStringAgent.bodyProducer is a tx_clients.utils.web.StringBodyProducer
+    # This makes it convenient to send strings as the body of the request
+    data = 'foo'
+    d = agent.post(url, data=data)
+
+__BasicFileAgent__
+
+    # BasicFileAgent.bodyProducer is a twisted.web.client.FileBodyProducer
+    # This makes it convenient to send file like objects as the body of the request. It can be used to stream open files.
+    with open('/path/to/file.txt', 'r') as fd:
+        d = agent.post(url, data=fd)
+
+__BasicJSONAgent__
+
+    # BasicJSONAgent.bodyProducer is a tx_clients.utils.web.JSONBodyProducer
+    # This makes it convenient to send JSONable python objects. Note: Default encoding is utf-8
+    data = {'foo': 'bar'}
+    d = agent.post(url, data=data)
+    # The content-type will also be set automatically.
+
+
+### Agent Invocation
+Agents can be invoked both synchronously and asynchronously.
+
+__Asynchronous Example__
+
+    from twisted.internet import reactor
+    from twisted.web import client
+
+    from tx_clients.clients import http
+
+    # Adding a pool is optional. A non persistent connection pool is created by default
+    pool = client.HTTPConnectionPool(reactor)
+    agent = http.BasicAgent(reactor, pool=pool)
+    d = agent.get('https://api.live.getpantheon.com:8443')
+
+    def print_response(response):
+        print response.body
+
+    d.addCallback(print_response)
+
+    def cbShutdown(response):
+        reactor.stop()
+    d.addBoth(cbShutdown)
+
+    reactor.run()
+
+__Inline Callbacks Example__ - Also Asynchronous but marginally slower.
+
+    from twisted.internet import reactor, defer
+    from twisted.web import client
+
+    from tx_clients.clients import http
+
+    @defer.inlineCallbacks
+    def main():
+        # Adding a pool is optional. A non persistent connection pool is created by default
+        pool = client.HTTPConnectionPool(reactor)
+        agent = http.BasicAgent(reactor, pool=pool)
+        response = yield agent.get('https://api.live.getpantheon.com:8443')
+        print response.body
+        reactor.stop()
+
+    main()
+    reactor.run()
+
+__Synchrnous Example__ - The Synchronous example requires [Crochet 1.4.0][] (Crochet 1.5.0 requires Twisted >= 15.0.0)
+
+    from twisted.internet import reactor
+    from twisted.web import client
+
+    from tx_clients.clients import http
+    
+    from crochet import setup, wait_for, TimeoutError
+    setup()
+
+    # Adding a pool is optional. A non persistent connection pool is created by default
+    pool = client.HTTPConnectionPool(reactor)
+    agent = http.BasicAgent(reactor, pool=pool)
+    try:
+        response = wait_for(timeout=1)(agent.get)('https://api.live.getpantheon.com:8443')
+        print response.body
+    except TimeoutError:
+        print 'Request Timed Out'
+
+## Line Client
+__TODO: DEPRECATE__ The notification-service (i.e. pubsub proxy) also has an http interface. We should discontinue use of the line protocol to the notification-service and instead use the http client below.
+
+A connection pooled client that speaks a simple line protocol. This protocol diverges slightly from the twisted implementation
+to adhere to the semantics of the notification-service (google pub/sub proxy) sidecar.
+
+The line client has a dependency upon txconnpool which is an older implementation of connection pooling.
+
+
+[twisted.web.client.Agent]: https://github.com/twisted/twisted/blob/twisted-12.2.0/twisted/web/client.py#L1096
+[twisted.web.client.ProxyAgent]: https://github.com/twisted/twisted/blob/twisted-12.2.0/twisted/web/client.py#L1211
+[twisted.web.client.CookieAgent]: https://github.com/twisted/twisted/blob/twisted-12.2.0/twisted/web/client.py#L1325
+[twisted.web.client.ContentDecoderAgent]: https://github.com/twisted/twisted/blob/twisted-12.2.0/twisted/web/client.py#L1463
+[twisted.web.client.RedirectAgent]: https://github.com/twisted/twisted/blob/twisted-12.2.0/twisted/web/client.py#L1526
+[twisted.web._newclient.HTTP11ClientProtocol]: https://github.com/twisted/twisted/blob/twisted-12.2.0/twisted/web/_newclient.py#L1190
+[twisted.web.iweb.IAgent]: https://github.com/twisted/twisted/blob/twisted-16.2.0/twisted/web/iweb.py#L633
+[Twisted 12.2.0 Client Documentation]: https://twistedmatrix.com/documents/12.2.0/web/howto/client.html
+[twisted.web.iweb.IBodyProducer]: https://github.com/twisted/twisted/blob/twisted-12.2.0/twisted/web/iweb.py#L633
+[twisted.web.client.WebClientContextFactory]: https://github.com/twisted/twisted/blob/twisted-12.2.0/twisted/web/client.py#L664
+[twisted.web.client.getPage]: https://github.com/twisted/twisted/blob/twisted-12.2.0/twisted/web/client.py#L611
+[twisted.web.client.downloadPage]: https://github.com/twisted/twisted/blob/twisted-12.2.0/twisted/web/client.py#L627
+[Crochet 1.4.0]: https://github.com/itamarst/crochet/tree/1.4.0
+[twisted.web.http_headers.Headers]: https://github.com/twisted/twisted/blob/twisted-12.3.0/twisted/web/http_headers.py#L105

--- a/src/tx_clients/clients/http.py
+++ b/src/tx_clients/clients/http.py
@@ -1,0 +1,259 @@
+#pylint: disable=protected-access, too-many-arguments, too-many-instance-attributes
+from collections import OrderedDict
+
+from zope.interface import implements
+
+from twisted.web import client, http
+from twisted.web.iweb import IResponse
+from twisted.internet import defer
+from twisted.web.http_headers import Headers
+from twisted.test.proto_helpers import StringTransport
+
+
+from tx_clients.utils.web import (
+    readBody,
+    JSONBodyProducer,
+    StringBodyProducer
+)
+
+# A dictionary is insufficient for supplying headers since a header may be
+# sent multiple times. Dont be lazy, Create a Headers object whenever possible
+dict_to_raw_headers = lambda h: Headers({k: [v] for k, v in h.viewitems()})
+
+class BasicResponse(object):
+    """ Return's a deferred that fires when the body is received
+    The body is attached as a parameter on the BasicResponse object
+    This is a helper which implements the twisted IResponse interface.
+    This wrapper provides an asynchronous way of waiting for the body.
+
+    An alternative is to read the response seperately the response object will
+    not be available to the final callback. Only the contents of the body.:
+        agent = Agent(reactor)
+        d = agent.request('GET', 'https://google.com')
+        d.addCallback(readBody)
+    """
+    def __init__(self):
+        """ BasicResponse objects wrap twisted.web.client.iweb.IResponse """
+        self._response = None
+        self.method = None
+        self.version = None
+        self.code = None
+        self.phrase = None
+        self.headers = None
+        self.length = None
+        self.body = None
+
+    implements(IResponse)
+    def __call__(self, response, method):
+        """
+        response See: twisted.web.client.iweb.IResponse
+        method: http verb
+        """
+        self._response = response
+        self.method = method
+        self.version = response.version
+        self.code = response.code
+        self.phrase = response.phrase
+        self.headers = response.headers
+        self.length = response.length
+        self.body = None
+        return self.deliverBody()
+
+    def cbAttachBody(self, body):
+        # Attach the body and return the BasicResponse object
+        self.body = body
+        # Should we log a warning if the length sent by the server mismatches?
+        self.length = len(body)
+        return self
+
+    def deliverBody(self):
+        if self._response.code in http.NO_BODY_CODES or self.method == 'HEAD':
+            return defer.succeed(self)
+        d = readBody(self._response)
+        d.addCallback(self.cbAttachBody)
+        return d
+
+
+class BasicAgent(client.Agent):
+    """ Returns a Deferred which contains a BasicResponse
+    Asynchronous HTTP Client Helper which makes some assumptions to satisfy the
+    majority of use cases. See: twisted.web.iweb.IAgent for the details of
+    the Agent interface.
+
+    - The deferred object waits for headers and the body to be delivered
+    before firing. It's result MUST be a Response object.
+    - The data attached to the request MUST be a string. Unicode is never valid.
+    The producer on the client will wrap the string.
+    - Headers MUST be a twisted.web.client.Headers object
+    - All semantics of the underlying agent also apply
+        - See: twisted.web.iweb.IAgent
+    - Provides a "requests" like interface
+
+    If your use case diverges from this pattern then you should probably be using
+    the twisted Agent directly. See Documentation:
+    https://twistedmatrix.com/documents/12.2.0/web/howto/client.html
+
+    Usage:
+        def cbResponse(response):
+            # Handle successful response
+            print response
+            return response
+        def ebFailure(failure):
+            # Handle failure while generating the response
+            print failure
+            return failure
+        client = BasicAgent(reactor)
+        d = client.get("https://127.0.0.1:8443/my/path")
+        d.addCallbacks(cbResponse, cbErrback)
+        return d
+    """
+    bodyProducer = StringBodyProducer
+    def request(self, method, uri, headers=None, data=None):
+        """ Returns an imutable Response object when the body is availabele """
+        producer = None
+        if data is not None:
+            producer = self.bodyProducer(data)
+
+        d = client.Agent.request(self, method, uri, headers, producer)
+        d.addCallback(BasicResponse(), method)
+        return d
+
+    def get(self, *args, **kwargs):
+        return self.request('GET', *args, **kwargs)
+
+    def delete(self, *args, **kwargs):
+        return self.request('DELETE', *args, **kwargs)
+
+    def post(self, *args, **kwargs):
+        return self.request('POST', *args, **kwargs)
+
+    def put(self, *args, **kwargs):
+        return self.request('PUT', *args, **kwargs)
+
+    def patch(self, *args, **kwargs):
+        return self.request('PATCH', *args, **kwargs)
+
+    def options(self, *args, **kwargs):
+        return self.request('OPTIONS', *args, **kwargs)
+
+    def head(self, *args, **kwargs):
+        return self.request('HEAD', *args, **kwargs)
+
+    def trace(self, *args, **kwargs):
+        return self.request('TRACE', *args, **kwargs)
+
+    def connect(self, *args, **kwargs):
+        return self.request('CONNECT', *args, **kwargs)
+
+
+class BasicFileAgent(BasicAgent):
+    """
+    See: BasicHTTPClient
+
+    - The basic File Agent asynchronously sends data from a file like object
+    - Automatically sets transfer encoding to chunked
+    """
+    bodyProducer = client.FileBodyProducer
+
+class BasicJSONAgent(BasicAgent):
+    """
+    See: BasicHTTPClient
+
+    - The basic JSON Agent asynchronously encodes and sends data as json
+    - Automatically sets the content-type
+    - Automatically sets transfer encoding to chunked
+    """
+    bodyProducer = JSONBodyProducer
+    def request(self, method, uri, headers=None, data=None):
+        if data is not None:
+            if headers is None:
+                headers = Headers()
+            headers.removeHeader('Content-Type')
+            headers.addRawHeader('Content-Type', 'application/json; charset=utf-8')
+        return BasicAgent.request(self, method, uri, headers, data)
+
+
+def stub_agent_factory(agent_cls):
+    """
+    The stub agent factory returns a stub agent that is a subclass of the
+    base class that is passed into the function.
+
+    This stub agent is a tool which can be used for unit tests as well as
+    generating contract tests. Gateway unit-tests should never perform any live
+    requests and so a stub agent should be used. For integration testing use a
+    live agent.
+
+    The stub agent collects requests in the order in which they are made. This
+    allows easy access to iteratively respond to the requests in an ordered manner.
+
+    Requests can only have one response or failure instance applied so a queue
+    is constructed to track which requests have already been acted upon.
+
+    The second tool is "live replay". All recorded requests are performed on a
+    live agent. The response to each request is stored in a live_request_history.
+    This is useful for recording the current state and behaivor of an external
+    api. The live replay is a good tool for generating mocks or scheama but
+    again it should not be used for integration testing.
+    """
+    class StubBasicAgent(agent_cls):
+        def __init__(self, *args, **kwargs):
+            self.args = args
+            self.kwargs = kwargs
+            self.request_history = OrderedDict()
+            self.request_queue = OrderedDict()
+            self.live_request_history = OrderedDict()
+
+        @defer.inlineCallbacks
+        def replay_live(self):
+            """
+            Performs live requests with a live agent. Requires networking.
+            This is a tool that is useful for generating live responses for
+            requests that have been recorded by the stub agent.
+
+            Live requests will only be performed once per request.
+            """
+            live_agent = agent_cls(*self.args, **self.kwargs)
+            for stub_response in self.request_history.viewkeys():
+                if stub_response not in self.live_request_history:
+                    args, kwargs = self.request_history[stub_response]
+                    try:
+                        live_response = yield live_agent.request(*args, **kwargs)
+                    except Exception as e: #pylint: disable=broad-except
+                        live_response = e
+                    self.live_request_history[stub_response] = ((args, kwargs), live_response)
+            yield defer.succeed(None)
+
+        def request(self, *args, **kwargs):
+            d_response = defer.Deferred()
+            self.request_history[d_response] = (args, kwargs)
+            self.request_queue[d_response] = (args, kwargs)
+            return d_response
+
+        @staticmethod
+        def stub_response(method, version, code, phrase, headers, body):
+            """ Build a stub response object. """
+            transport = StringTransport()
+            res = client.Response(version, code, phrase, headers, transport)
+            res._bodyDataReceived(body)
+            res._bodyDataFinished()
+            return BasicResponse()(res, method).result
+
+        def respond(self, version, code, phrase, headers, body):
+            """ Respond to requests in FIFO order. """
+            d_response, params = self.request_queue.popitem(False)
+            args, kwargs = params
+            method = args[0] if args else kwargs['method']
+            response = self.stub_response(method, version, code, phrase, headers, body)
+            d_response.callback(response)
+
+        def fail(self, reason):
+            """
+            Fail requests in FIFO order.
+            reason Exception. An exception instance to pass to the errback chain.
+            """
+            d_response, _ = self.request_queue.popitem(False)
+            d_response.errback(reason)
+
+    return StubBasicAgent
+
+

--- a/src/tx_clients/clients/tests/test_http.py
+++ b/src/tx_clients/clients/tests/test_http.py
@@ -1,0 +1,243 @@
+import cPickle
+
+from mock import patch, MagicMock
+from twisted.trial import unittest
+
+from twisted.internet import reactor
+from twisted.web import client
+from twisted.web.http_headers import Headers
+from twisted.test.proto_helpers import StringTransport
+
+from tx_clients.clients import http
+
+class Matcher(object):
+    """ General purpose matcher for comparing objects """
+    def __init__(self, compare, obj):
+        self.compare = compare
+        self.obj = obj
+    def __eq__(self, other):
+        return self.compare(self.obj, other)
+
+def compare_bodyProducer(self, other):
+    if not type(self) == type(other):
+        return False
+    return cPickle.dumps(other) == cPickle.dumps(self)
+
+class TestBasicAgent(unittest.TestCase):
+    def setUp(self):
+        self.patch_request = patch('tx_clients.clients.http.BasicAgent.request')
+        self.mock_request = self.patch_request.start()
+        self.agent = http.BasicAgent(reactor)
+        self.url = 'foo'
+
+    def test_get(self):
+        self.agent.get(self.url)
+        self.mock_request.assert_called_once_with('GET', self.url)
+
+    def test_delete(self):
+        self.agent.delete(self.url)
+        self.mock_request.assert_called_once_with('DELETE', self.url)
+
+    def test_post(self):
+        self.agent.post(self.url)
+        self.mock_request.assert_called_once_with('POST', self.url)
+
+    def test_put(self):
+        self.agent.put(self.url)
+        self.mock_request.assert_called_once_with('PUT', self.url)
+
+    def test_patch(self):
+        self.agent.patch(self.url)
+        self.mock_request.assert_called_once_with('PATCH', self.url)
+
+    def test_options(self):
+        self.agent.options(self.url)
+        self.mock_request.assert_called_once_with('OPTIONS', self.url)
+
+    def test_head(self):
+        self.agent.head(self.url)
+        self.mock_request.assert_called_once_with('HEAD', self.url)
+
+    def test_trace(self):
+        self.agent.trace(self.url)
+        self.mock_request.assert_called_once_with('TRACE', self.url)
+
+    def test_connect(self):
+        self.agent.connect(self.url)
+        self.mock_request.assert_called_once_with('CONNECT', self.url)
+
+    @patch('twisted.web.client.Agent.request')
+    def test_request(self, mock_request):
+        self.patch_request.stop()
+        args = ('GET', self.url)
+        self.agent.request(*args)
+        mock_request.assert_called_once_with(self.agent, *args + (None, None))
+        mock_request.reset_mock()
+
+        args = ('GET', self.url)
+        data = 'foo'
+        self.agent.request(*args, data=data)
+        match_bodyProducer = Matcher(compare_bodyProducer, self.agent.bodyProducer(data))
+        mock_request.assert_called_once_with(self.agent, *args + (None, match_bodyProducer))
+        mock_request.reset_mock()
+
+        headers = Headers()
+        headers.addRawHeader('Content-Type', 'application/json')
+        args = ('GET', self.url, headers)
+        self.agent.request(*args, data='foo')
+        match_bodyProducer = Matcher(compare_bodyProducer, self.agent.bodyProducer(data))
+        mock_request.assert_called_once_with(self.agent, *args + (match_bodyProducer,))
+        mock_request.reset_mock()
+
+        headers = Headers()
+        headers.addRawHeader('Content-Type', 'application/json')
+        args = ('GET', self.url, headers, None)
+        self.agent.request(*args)
+        mock_request.assert_called_once_with(self.agent, *args)
+
+    def tearDown(self):
+        self.mock_request.reset_mock()
+        # A Test may pre-emptively stop a patcher.
+        try:
+            self.patch_request.stop()
+        except RuntimeError:
+            pass
+
+
+class TestBasicFileAgent(TestBasicAgent):
+    def setUp(self):
+        self.patch_request = patch('tx_clients.clients.http.BasicFileAgent.request')
+        self.mock_request = self.patch_request.start()
+        self.agent = http.BasicFileAgent(reactor)
+        self.url = 'foo'
+
+
+class TestBasicJSONAgent(TestBasicAgent):
+    def setUp(self):
+        self.patch_request = patch('tx_clients.clients.http.BasicJSONAgent.request')
+        self.mock_request = self.patch_request.start()
+        self.agent = http.BasicJSONAgent(reactor)
+        self.url = 'foo'
+
+    @patch('twisted.web.client.Agent.request')
+    def test_request(self, mock_request):
+        self.patch_request.stop()
+        args = ('GET', self.url)
+        self.agent.request(*args)
+        mock_request.assert_called_once_with(self.agent, *args + (None, None))
+        mock_request.reset_mock()
+
+        args = ('GET', self.url)
+        data = 'foo'
+        self.agent.request(*args, data=data)
+        match_bodyProducer = Matcher(compare_bodyProducer, self.agent.bodyProducer(data))
+        headers = Headers()
+        headers.addRawHeader('Content-Type', 'application/json; charset=utf-8')
+        mock_request.assert_called_once_with(self.agent, *args + (headers, match_bodyProducer))
+        mock_request.reset_mock()
+
+        args = ('GET', self.url, None, 'foo')
+        self.agent.request(*args)
+        match_bodyProducer = Matcher(compare_bodyProducer, self.agent.bodyProducer(args[-1]))
+        headers = Headers()
+        headers.addRawHeader('Content-Type', 'application/json; charset=utf-8')
+        mock_request.assert_called_once_with(self.agent, *args[:2] + (headers, match_bodyProducer))
+        mock_request.reset_mock()
+
+        headers = Headers()
+        headers.addRawHeader('Content-Type', 'application/json')
+        args = ('GET', self.url, headers)
+        self.agent.request(*args, data='foo')
+        match_bodyProducer = Matcher(compare_bodyProducer, self.agent.bodyProducer(data))
+        mock_request.assert_called_once_with(self.agent, *args + (match_bodyProducer,))
+        mock_request.reset_mock()
+
+        headers = Headers()
+        headers.addRawHeader('Content-Type', 'application/json')
+        args = ('GET', self.url, headers, None)
+        self.agent.request(*args)
+        mock_request.assert_called_once_with(self.agent, *args)
+
+
+
+class TestHttp(unittest.TestCase):
+    def test_dict_to_raw_headers(self):
+        headers = {
+            "Content-Type": "application/json; charset=utf-8"
+        }
+        headers_obj = http.dict_to_raw_headers(headers)
+        for header in headers:
+            self.assertEquals(headers_obj.getRawHeaders(header), [headers[header]])
+
+class TestBasicResponse(unittest.TestCase):
+    def setUp(self):
+        self.version = 'mock version'
+        self.code = 'mock code'
+        self.phrase = 'mock phrase'
+        self.headers = 'mock headers'
+        self.body = 'foo'
+        self.length = len(self.body)
+        self.transport = StringTransport()
+        self.stub_response = client.Response(
+            self.version,
+            self.code,
+            self.phrase,
+            self.headers,
+            self.transport
+        )
+        self.stub_response.length = self.length
+        self.stub_response._bodyDataReceived(self.body)
+        self.stub_response._bodyDataFinished()
+
+    def test_basic_response_method_HEAD(self):
+        response_wrapper = http.BasicResponse()
+        wrapped_response = response_wrapper(self.stub_response, 'HEAD').result
+        self.assertEquals(wrapped_response, response_wrapper)
+        self.assertEquals(wrapped_response.method, response_wrapper.method)
+        self.assertEquals(wrapped_response.version, self.stub_response.version)
+        self.assertEquals(wrapped_response.code, self.stub_response.code)
+        self.assertEquals(wrapped_response.phrase, self.stub_response.phrase)
+        self.assertEquals(wrapped_response.headers, self.stub_response.headers)
+        self.assertEquals(wrapped_response.length, self.stub_response.length)
+        self.assertEquals(wrapped_response.body, None)
+
+    def test_basic_response_no_body_code(self):
+        response_wrapper = http.BasicResponse()
+        self.stub_response.code = 204
+        wrapped_response = response_wrapper(self.stub_response, 'POST').result
+
+        self.assertEquals(wrapped_response, response_wrapper)
+        self.assertEquals(wrapped_response.method, response_wrapper.method)
+        self.assertEquals(wrapped_response.version, self.stub_response.version)
+        self.assertEquals(wrapped_response.code, self.stub_response.code)
+        self.assertEquals(wrapped_response.phrase, self.stub_response.phrase)
+        self.assertEquals(wrapped_response.headers, self.stub_response.headers)
+        self.assertEquals(wrapped_response.length, self.stub_response.length)
+        self.assertEquals(wrapped_response.body, None)
+
+        self.stub_response.code = 304
+        wrapped_response = response_wrapper(self.stub_response, 'POST').result
+
+        self.assertEquals(wrapped_response, response_wrapper)
+        self.assertEquals(wrapped_response.method, response_wrapper.method)
+        self.assertEquals(wrapped_response.version, self.stub_response.version)
+        self.assertEquals(wrapped_response.code, self.stub_response.code)
+        self.assertEquals(wrapped_response.phrase, self.stub_response.phrase)
+        self.assertEquals(wrapped_response.headers, self.stub_response.headers)
+        self.assertEquals(wrapped_response.length, self.stub_response.length)
+        self.assertEquals(wrapped_response.body, None)
+
+    def test_basic_response_GET_200(self):
+        response_wrapper = http.BasicResponse()
+        self.stub_response.code = 200
+        wrapped_response = response_wrapper(self.stub_response, 'GET').result
+
+        self.assertEquals(wrapped_response, response_wrapper)
+        self.assertEquals(wrapped_response.method, response_wrapper.method)
+        self.assertEquals(wrapped_response.version, self.stub_response.version)
+        self.assertEquals(wrapped_response.code, self.stub_response.code)
+        self.assertEquals(wrapped_response.phrase, self.stub_response.phrase)
+        self.assertEquals(wrapped_response.headers, self.stub_response.headers)
+        self.assertEquals(wrapped_response.length, self.stub_response.length)
+        self.assertEquals(wrapped_response.body, self.body)
+

--- a/src/tx_clients/utils/web.py
+++ b/src/tx_clients/utils/web.py
@@ -1,0 +1,146 @@
+import base64
+import cStringIO
+import json
+import warnings
+
+from zope.interface import implements
+
+from twisted.web import client
+from twisted.web.iweb import IBodyProducer
+from twisted.internet import defer, protocol
+from twisted.internet.task import cooperate
+from twisted.web.http import PotentialDataLoss
+
+
+class StringBodyProducer(client.FileBodyProducer):
+    """ See: twisted.web.client.FileBodyProducer """
+    def __init__(self, string, *args, **kwargs):
+        """ The FileBodyProducer accepts file like objects """
+        client.FileBodyProducer.__init__(self, cStringIO.StringIO(string), *args, **kwargs)
+
+
+class JSONBodyProducer(object):
+    """ See: twisted.web.iweb.IBodyProducer """
+    implements(IBodyProducer)
+
+    def __init__(self, body):
+        self.body = body
+        self.length = client.UNKNOWN_LENGTH
+        self._consumer = None
+        self._iterable = None
+        self._task = None
+
+    def startProducing(self, consumer):
+        self._consumer = consumer
+        self._iterable = json.JSONEncoder().iterencode(self.body)
+        self._task = cooperate(self._produce())
+        d = self._task.whenDone()
+        return d
+
+    def pauseProducing(self):
+        self._task.pause()
+
+    def resumeProducing(self):
+        self._task.resume()
+
+    def stopProducing(self):
+        self._task.stop()
+
+    def _produce(self):
+        for chunk in self._iterable:
+            self._consumer.write(chunk)
+            yield None
+
+
+# Ported from twisted.web.client version Twisted 16.2.0
+class _ReadBodyProtocol(protocol.Protocol):
+    """
+    Protocol that collects data sent to it.
+    This is a helper for L{IResponse.deliverBody}, which collects the body and
+    fires a deferred with it.
+    """
+
+    def __init__(self, status, message, deferred):
+        """
+        @param status: Status of L{IResponse}
+        @ivar status: L{int}
+        @param message: Message of L{IResponse}
+        @type message: L{bytes}
+        @param deferred: deferred to fire when response is complete
+        @type deferred: L{Deferred} firing with L{bytes}
+        """
+        self.deferred = deferred
+        self.status = status
+        self.message = message
+        self.dataBuffer = []
+
+
+    def dataReceived(self, data):
+        """
+        Accumulate some more bytes from the response.
+        """
+        self.dataBuffer.append(data)
+
+
+    def connectionLost(self, reason=protocol.connectionDone):
+        """
+        Deliver the accumulated response bytes to the waiting L{Deferred}, if
+        the response body has been completely received without error.
+        """
+        if reason.check(client.ResponseDone):
+            self.deferred.callback(b''.join(self.dataBuffer))
+        elif reason.check(PotentialDataLoss):
+            self.deferred.errback(
+                client.PartialDownloadError(
+                    self.status,
+                    self.message,
+                    b''.join(self.dataBuffer)
+                )
+            )
+        else:
+            self.deferred.errback(reason)
+
+
+# Ported from twisted.web.client version Twisted 16.2.0
+def readBody(response):
+    """
+    Get the body of an L{IResponse} and return it as a byte string.
+    This is a helper function for clients that don't want to incrementally
+    receive the body of an HTTP response.
+    @param response: The HTTP response for which the body will be read.
+    @type response: L{IResponse} provider
+    @return: A L{Deferred} which will fire with the body of the response.
+        Cancelling it will close the connection to the server immediately.
+    """
+    def cancel(deferred):
+        """
+        Cancel a L{readBody} call, close the connection to the HTTP server
+        immediately, if it is still open.
+        @param deferred: The cancelled L{defer.Deferred}.
+        """
+        abort = getAbort()
+        if abort is not None:
+            abort()
+    d = defer.Deferred(cancel)
+    proto = _ReadBodyProtocol(response.code, response.phrase, d)
+    def getAbort():
+        return getattr(proto.transport, 'abortConnection', None)
+
+    response.deliverBody(proto)
+
+    if proto.transport is not None and getAbort() is None:
+        warnings.warn(
+            'Using readBody with a transport that does not have an '
+            'abortConnection method',
+            category=DeprecationWarning,
+            stacklevel=2
+        )
+
+    return d
+
+
+def generate_basic_authorization_string(user, password):
+    # Basic Auth Credentials
+    base64string = base64.encodestring('%s:%s' % (user, password))[:-1]
+    return "Basic %s" % base64string
+


### PR DESCRIPTION
See Useage Documentation: https://github.com/pantheon-systems/tx_clients/tree/generic_http_client/src/tx_clients/clients

This is meant to be a general purpose http client that has no ygg or titan-mt dependencies. It uses pure twisted interfces.

This client attempts to simplify the twisted interface a bit. See: http://martinfowler.com/articles/microservice-testing/#testing-progress-3
(how it fits into a microservice)
